### PR TITLE
Use type -q instead of type > /dev/null

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -12,7 +12,7 @@ alias mv='mv -i'
 alias cp='cp -i'
 
 # fasd
-if type fasd > /dev/null
+if type -q fasd
   alias v='fasd -t -e vim -b viminfo'
 end
 


### PR DESCRIPTION
`type -q` is better becase `> /dev/null` only silences `stdout` while `-q` correctly deals with `stderr` as well. `-q` also saves unnecessary calls of `sys_write`.
